### PR TITLE
Queued job fixes and enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,25 @@ This is a queued job that can be used to send emails depending on the ```send_vi
 + 'when-attachments' - only when attachments are present, or
 + 'no' - never (in which case messages will never send via a Queued Job)
 
-Relevant messages are handed off to the queued job, which is configured to send after one minute. Once delivered, the message parameters are cleared to reduce space used by large messages.
+Messages are handed off to this queued job, which is configured to send after one minute. Once delivered, the message parameters are cleared to reduce space used by large messages.
+
+This job is marked as 'broken' immediately upon an API or other general error.
 
 ### TruncateJob
 
-Use this job to clear out older MailgunEvent records.
+Use this job to clear out older MailgunEvent webhook records.
+
+### RequeueJob
+
+Use this job to kick broken SendJob instances, which happen from time-to-time due to API or connectivity issues.
+
+This job will:
+1. Take all job descriptor records for SendJob that are Broken
+1. Reset their status, processing counts and worker value to default initial values
+1. Set them to start after a minute
+1. Save the record
+
+On the next queue run, these jobs will attempt to send again.
 
 ## Manual Resubmission
 

--- a/src/Exceptions/JobProcessingException.php
+++ b/src/Exceptions/JobProcessingException.php
@@ -1,0 +1,9 @@
+<?php
+namespace NSWDPC\Messaging\Mailgun;
+
+/**
+ * This exception is thrown when an error occurs in a job
+ */
+class JobProcessingException extends \Exception
+{
+}

--- a/src/Jobs/RequeueJob.php
+++ b/src/Jobs/RequeueJob.php
@@ -1,0 +1,90 @@
+<?php
+namespace NSWDPC\Messaging\Mailgun;
+
+use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
+use Symbiote\QueuedJobs\Services\QueuedJob;
+use SilverStripe\Core\Config\Config;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
+
+/**
+ * @author James Ellis <james.ellis@dpc.nsw.gov.au>
+ * Job used to requeue SendJob descriptors marked broken
+ * This is helpful if you have high mail traffic and have many broken {@link SendJob} records sitting in the queue
+ */
+class RequeueJob extends AbstractQueuedJob
+{
+
+    public function getTitle()
+    {
+        return _t(
+            __CLASS__ . ".JOB_TITLE",
+            "Re-queue failed attempts to send messages via the Mailgun API"
+        );
+    }
+
+    /**
+     * Attempt to send the message via the Mailgun API
+     */
+    public function process()
+    {
+
+        $descriptors = QueuedJobDescriptor::get()
+            ->filter([
+                'JobStatus' => QueuedJob::STATUS_BROKEN,
+                'Implementation' => SendJob::class
+            ]);
+        $count = $descriptors->count();
+        $kick = $skip = 0;
+        if($count > 0) {
+            $this->totalSteps = $count;
+            foreach($descriptors as $descriptor) {
+
+                $data = @unserialize($descriptor->SavedJobData);
+                if(empty($data->parameters)) {
+                    // parameters cleared so pointless re-queuing
+                    $skip++;
+                    continue;
+                }
+
+                // recreate this job as new
+                $next = new \Datetime();
+                $next->modify('+1 minute');
+
+                $descriptor->StartAfter = $next->format('Y-m-d H:i:s');
+                $descriptor->JobStatus = QueuedJob::STATUS_NEW;
+                $descriptor->StepsProcessed = 0;
+                $descriptor->LastProcessedCount = -1;
+                $descriptor->Worker = null;// clear otherwise job is considered locked
+                $descriptor->write();
+
+                $kick++;
+                $this->currentStep++;
+            }
+
+            $this->addMessage(
+                _t(
+                    __CLASS__ . '.JOB_STATUS',
+                    "Marked {kick}, ignored {skip} broken SendJob descriptors as new",
+                    [
+                        'kick' => $kick,
+                        'skip' => $skip
+                    ]
+                ),
+                "info"
+            );
+
+        } else {
+            $this->addMessage(
+                _t(
+                    __CLASS__ . '.JOB_STATUS_NO_JOBS',
+                    "No jobs can be re-queued"
+                ),
+                "info"
+            );
+        }
+
+        $this->isComplete = true;
+
+    }
+}

--- a/src/Jobs/SendJob.php
+++ b/src/Jobs/SendJob.php
@@ -7,8 +7,6 @@ use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJob;
 use SilverStripe\Core\Config\Config;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
-use DateTime;
-use DateTimeZone;
 
 /**
  * @author James Ellis <james.ellis@dpc.nsw.gov.au>
@@ -16,25 +14,48 @@ use DateTimeZone;
  */
 class SendJob extends AbstractQueuedJob
 {
+
+    /**
+     * Total steps for this job
+     * @var int
+     */
     protected $totalSteps = 1;
 
+    /**
+     * @var \NSWDPC\Messaging\Mailgun\Connector\Message
+     */
     protected $connector;
 
+    /**
+     * Job type
+     */
     public function getJobType()
     {
-        $this->totalSteps = 1;
         return QueuedJob::QUEUED;
     }
 
     public function getTitle()
     {
-        $to = $this->parameters['to'] ?? 'to not set';
-        $subject = $this->parameters['subject'] ?? 'subject not set';
-        $from = $this->parameters['from'] ?? 'from not set';
-        $testmode = $this->parameters['o:testmode'] ?? 'no';
-        return "Email via Mailgun To: '{$to}' From: '{$from}' Subject: '{$subject}' TestMode: '{$testmode}'";
+        $parameters = $this->parameters;
+        $to = $parameters['to'] ?? 'to not set';
+        $subject = $parameters['subject'] ?? 'subject not set';
+        $from = $parameters['from'] ?? 'from not set';
+        $testmode = $parameters['o:testmode'] ?? 'no';
+        return _t(
+            __CLASS__ . ".JOB_TITLE",
+            "Email via Mailgun To: '{to}' From: '{from}' Subject: '{subject}' Test mode: '{testmode}'",
+            [
+                'to' => $to,
+                'from' => $from,
+                'subject' => $subject,
+                'testmode' => $testmode
+            ]
+        );
     }
 
+    /**
+     * The job signature is a combination of the API domain and the job parameters
+     */
     public function getSignature()
     {
         return md5($this->domain . ":" . serialize($this->parameters));
@@ -49,7 +70,9 @@ class SendJob extends AbstractQueuedJob
     {
         $this->connector = new MessageConnector;
         $this->domain = $this->connector->getApiDomain();
-        $this->parameters = $parameters;
+        if(!empty($parameters)) {
+            $this->parameters = $parameters;
+        }
     }
 
     /**
@@ -58,50 +81,96 @@ class SendJob extends AbstractQueuedJob
     public function process()
     {
 
-        if ($this->isComplete) {
-            return;
-        }
-
-        $this->currentStep += 1;
-
-        $client = $this->connector->getClient();
-        $domain = $this->connector->getApiDomain();
-
-        if (!$domain) {
-            $msg = "Mailgun SendJob is missing the Mailgun API domain value";
-            $this->messages[] = $msg;
-            throw new \Exception($msg);
-        }
-
-        if(empty($this->parameters)) {
-            $msg = "Mailgun SendJob was called with empty parameters";
-            $this->messages[] = $msg;
-            throw new \Exception($msg);
-        }
-
-        $msg = "Unknown error";
         try {
+
+            if ($this->isComplete) {
+                // the job has already been marked complete
+                return;
+            }
+
+            $this->currentStep++;
+
+            $client = $this->connector->getClient();
+            $domain = $this->connector->getApiDomain();
+
+            if (!$domain) {
+                $msg = _t(
+                    __CLASS__ . ".MISSING_API_DOMAIN",
+                    "Mailgun configuration is missing the Mailgun API domain value"
+                );
+                throw new JobProcessingException($msg);
+            }
+
+            $parameters = $this->parameters;
+            if(empty($parameters)) {
+                $msg = _t(
+                    __CLASS__ . ".EMPTY_PARAMS",
+                    "Mailgun SendJob was called with empty parameters"
+                );
+                throw new JobProcessingException($msg);
+            }
+
             // if required, apply the default recipient
-            $this->connector->applyDefaultRecipient($this->parameters);
+            $this->connector->applyDefaultRecipient($parameters);
             // decode all attachments
-            $this->connector->decodeAttachments($this->parameters);
+            $this->connector->decodeAttachments($parameters);
             // send directly via the API client
-            $response = $client->messages()->send($domain, $this->parameters);
+            $response = $client->messages()->send($domain, $parameters);
             $message_id = "";
+
             if ($response && ($response instanceof SendResponse) && ($message_id = $response->getId())) {
                 $message_id = MessageConnector::cleanMessageId($message_id);
-                $this->parameters = [];//remove all params
-                $msg = "OK {$message_id}";
-                $this->messages[] = $msg;
+                $this->parameters = [];//remove all params once message is Accepted by Mailgun
+                $this->addMessage("OK {$message_id}", "INFO");
                 $this->isComplete = true;
                 return;
             }
-            throw new \Exception("SendJob invalid response or no message.id returned");
-        } catch (Exception $e) {
-            // API level errors caught here
-            $msg = $e->getMessage();
+
+            // handle if the response is invalid
+            throw new JobProcessingException(
+                $this->addMessage(
+                    _t(
+                        __CLASS__ . ".SEND_INVALID_RESPONSE_FROM_MAILGUN",
+                        "SendJob invalid response or no message.id returned"
+                    )
+                )
+            );
+
+        } catch (JobProcessingException $e) {
+            $this->addMessage(
+                _t(
+                    __CLASS__ . ".SEND_EXCEPTON",
+                    "Mailgun send processing exception: {error}",
+                    [
+                        "error" => $e->getMessage()
+                    ]
+                ),
+                "ERROR"
+            );
+        } catch (\Exception $e) {
+            $this->addMessage(
+                _t(
+                    __CLASS__ . ".GENERAL_EXCEPTON",
+                    "Mailgun send general exception: {error}",
+                    [
+                        "error" => $e->getMessage()
+                    ]
+                ),
+                "ERROR"
+            );
         }
-        $this->messages[] = $msg;
-        throw new \Exception($msg);
+
+        /**
+         * Mark the job as broken. This avoids repeated requests to the  API
+         * for the same send attempt and possibly cause quota issues.
+         * Semd attempts that arrive here need to be manually re-queued
+         */
+        throw new \Exception(
+            _t(
+                __CLASS__ . ".MAILGUN_SEND_FAILED",
+                "Mailgun send failed. Check status.mailgun.com or connectivity?"
+            )
+        );
+
     }
 }


### PR DESCRIPTION
From time-to-time send jobs can fail, this PR fixes some issues and adds support for re-sending broken queued send jobs

## Changes
+ Fix: When the API domain was changed, any emails in the queue would fail as the previous API domain at the time of job creation was being used (e.g changing from sandbox to production domain). Always take the API domain value from configuration.
+ Enhancement: handle failing send jobs better, add a RequeueJob to find broken send jobs and set them to new status, to be picked up on the next queue run.
+ Update README to reflect change