### PR TITLE
Fix #5: Resolve invalid validation of attachments.

### DIFF
--- a/src/Email/Mailer.php
+++ b/src/Email/Mailer.php
@@ -107,12 +107,7 @@ class MailgunMailer implements Mailer
             $connector = $email->getConnector();
 
             // process attachments
-            if (!empty($attachments)) {
-                $attachments = $this->prepareAttachments($message->getChildren());
-            } else {
-                // eensure empty array
-                $attachments = [];
-            }
+            $attachments = $this->prepareAttachments($message->getChildren());
 
             // process headers
             $headers = $message->getHeaders();


### PR DESCRIPTION
The problem here is `$attachments` not being defined. Since the prepareAttachments method is returning an empty array when no attachments are present anyway, just remove the whole condition.